### PR TITLE
build(deps): Bump `node` from `v14` to `v16`

### DIFF
--- a/.github/workflows/fetch-data.yml
+++ b/.github/workflows/fetch-data.yml
@@ -17,9 +17,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Install dependencies
         run: yarn install

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@types/dotenv": "^8.2.0",
     "@types/ical": "./src/types/ical.js",
     "@types/jsdom": "^16.2.5",
-    "@types/node": "^14.14.10",
+    "@types/node": "^18.7.3",
     "@types/node-fetch": "^2.5.7",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "path": "^0.12.7",
     "rss-parser": "^3.9.0"
   },
+  "engines": {
+    "node": "^16.16.0"
+  },
   "scripts": {
     "start": "node dist/index.js",
     "dev": "ts-node ./index.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,10 +81,15 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@^14.14.10":
+"@types/node@*":
   version "14.14.10"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.10.tgz#5958a82e41863cfc71f2307b3748e3491ba03785"
   integrity sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==
+
+"@types/node@^18.7.3":
+  version "18.7.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.3.tgz#432c89796eab539b7a30b7b8801a727b585238a4"
+  integrity sha512-LJgzOEwWuMTBxHzgBR/fhhBOWrvBjvO+zPteUgbbuQi80rYIZHrk1mNbRUqPZqSLP2H7Rwt1EFLL/tNLD1Xx/w==
 
 "@types/parse5@*":
   version "5.0.3"


### PR DESCRIPTION
This PR bumps the `node` version for the scraper from `v14` to `v16`

* build(deps): Bump @types/node from `14.14.10` to `18.7.1`
* build(actions): Bump github-actions node version to `v16`